### PR TITLE
Add USDT token to JustSwap default list

### DIFF
--- a/example.justlists.ts
+++ b/example.justlists.ts
@@ -120,6 +120,14 @@
             "decimals":18,
             "name":"HuobiToken",
             "logoURI":"https://coin.top/production/logo/TDyvndWuvX5xTBwHPYJi7J3Yq8pq8yh62h.png"
+        },
+        {
+            "symbol":"USDT",
+            "address":"TPHjxwvDiAJtnySMo99ou7Rbqo8cqVhsh",
+            "chainId":1,
+            "decimals":6,
+            "name":"Tether USD",
+            "logoURI":"https://gateway.pinata.cloud/ipfs/bafybeihxt2slp3smg3d2qhawkwr4iwhhna4w4huh3254r6c33qmtkmbhxi"
         }
     ],
     "logoURI":"https://justswap.io/favicon.ico",
@@ -129,4 +137,4 @@
         "minor":0
     },
     "timestamp":1611147166000
-}
+            }


### PR DESCRIPTION
This PR adds the Tether USD (USDT) token with the correct logo URI to the JustSwap default list.

Token Details:
- Symbol: USDT
- Address: TPHjxwvDiAJtnySMo99ou7Rbqo8cqVhsh
- Decimals: 6
- Name: Tether USD
- Logo URI: https://gateway.pinata.cloud/ipfs/bafybeihxt2slp3smg3d2qhawkwr4iwhhna4w4huh3254r6c33qmtkmbhxi

The token is on TRON Mainnet and follows the JustLists standard.